### PR TITLE
Detect and remove matches

### DIFF
--- a/Assets/Scripts/Game/BoardManager.cs
+++ b/Assets/Scripts/Game/BoardManager.cs
@@ -411,10 +411,12 @@ namespace ColorMatchRush
                     if (grid[r, c] == null)
                     {
                         Debug.LogWarning($"[BoardManager] Attempting to clear an already-null cell at ({r},{c}).");
+                        cleared = true; // cell is already clear; safe to destroy
                     }
                     else if (grid[r, c] == piece)
                     {
                         grid[r, c] = null;
+                        cleared = true; // successfully cleared by declared indices
                     }
                 }
 
@@ -432,14 +434,23 @@ namespace ColorMatchRush
                             }
                         }
                     }
-        #if UNITY_EDITOR
+#if UNITY_EDITOR
                     if (!cleared)
                         Debug.LogWarning($"[BoardManager] Matched piece not found in grid (id={piece.GetInstanceID()}).");
-        #endif
+#endif
                 }
 
-                Destroy(piece.gameObject);
-                removed++;
+                if (cleared || grid == null)
+                {
+                    Destroy(piece.gameObject);
+                    removed++;
+                }
+#if UNITY_EDITOR
+                else
+                {
+                    Debug.LogWarning($"[BoardManager] Skip destroying piece (id={piece.GetInstanceID()}) because grid reference wasn't cleared.");
+                }
+#endif
             }
 
             return removed;


### PR DESCRIPTION
## Summary
- Implemented `FindAllMatches()` to detect horizontal/vertical runs of 3+ pieces  
- Implemented `RemoveMatches()` to destroy matched pieces and clear grid cells

## How to test
1. Open **GameScene.unity**  
2. Run the scene and perform a valid swap (adjacent pieces forming a match)  
   - Confirm that the matched pieces are removed and grid cells set to null 

## Issue
Closes #3
