### PR TITLE
Handle tile fall and refill

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -165,6 +165,12 @@ MonoBehaviour:
   explicitOrigin: {x: 0, y: 0}
   generateOnStart: 1
   randomSeed: 0
+  preventInstantMatchesOnStart: 1
+  swapMoveDuration: 0.12
+  swapInProgress: 0
+  isResolving: 0
+  fallMoveDuration: 0.25
+  spawnOvershootCells: 1
 --- !u!4 &350540675
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Game/BoardManager.cs
+++ b/Assets/Scripts/Game/BoardManager.cs
@@ -150,14 +150,13 @@ namespace ColorMatchRush
         {
             if (!preventInstantMatchesOnStart || grid == null) return;
 
-            const int maxRegen = 5;
-            for (int i = 0; i < maxRegen; i++)
+            for (int i = 0; i < maxInstantMatchRegenerations; i++)
             {
                 var matches = FindAllMatches();
                 if (matches == null || matches.Count == 0) return; // already clean
 
                 // Re-generate with the avoidance picker to try a clean board
-                Debug.LogWarning($"[BoardManager] Instant matches detected at start. Regenerating (attempt {i + 1}/{maxRegen})...");
+                Debug.LogWarning($"[BoardManager] Instant matches detected at start. Regenerating (attempt {i + 1}/{maxInstantMatchRegenerations})...");
                 GenerateBoardInternal(avoidInstantMatches: true);
             }
         }

--- a/Assets/Scripts/Game/BoardManager.cs
+++ b/Assets/Scripts/Game/BoardManager.cs
@@ -120,10 +120,10 @@ namespace ColorMatchRush
                 return null;
             }
 
-            const int maxAttempts = 12;
+            const int MaxAttemptsToAvoidInstantMatch = 12;
             Piece lastTried = null;
 
-            for (int attempt = 0; attempt < maxAttempts; attempt++)
+            for (int attempt = 0; attempt < MaxAttemptsToAvoidInstantMatch; attempt++)
             {
                 int idx = Random.Range(0, piecePrefabs.Length);
                 var prefab = piecePrefabs[idx];

--- a/Assets/Scripts/Game/BoardManager.cs
+++ b/Assets/Scripts/Game/BoardManager.cs
@@ -32,6 +32,8 @@ namespace ColorMatchRush
         private int randomSeed = 0;
         [SerializeField, Tooltip("Avoid 3-in-a-row/column at startup.")]
         private bool preventInstantMatchesOnStart = true;
+        [SerializeField, Tooltip("Maximum times to regenerate board to avoid instant matches.")]
+        private int maxInstantMatchRegenerations = 5;
 
         // Grid storage (row-major: [row, column])
         private Piece[,] grid;


### PR DESCRIPTION
## Summary
- Added falling and refill logic (`CollapseColumnsDownward`, `RefillNewPiecesFromTop`)  
- Implemented `ResolveBoardLoop()` for cascades with input lock  
- Prevented instant matches on startup  
- Added `ShuffleBoard()` for deadboard handling  
- Adjusted `fallMoveDuration`  

## How to test
- Run `GameScene.unity`  
- Confirm pieces fall and refill after matches  
- Cascades resolve automatically until stable  
- No instant matches on start, shuffle occurs if no valid moves  

## Issue
Closes #4